### PR TITLE
fix(lighting-app): correct bl616cl boot pin

### DIFF
--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -82,7 +82,7 @@ BL616 / BL616CL
 │   └── Ethernet         ->  Matter over IP (TCP/UDP)
 ├── BLE                  ->  BLE commissioning (PASE over BLE)
 └── Application
-    ├── BOOT_PIN_RESET   (GPIO 2 on BL616DK, GPIO 38 on BL616CL)
+    ├── BOOT_PIN_RESET   (GPIO 2 on BL616DK, GPIO 36 on BL616CL)
     ├── LED_B_PIN        (GPIO 0)  - blue PWM channel
     ├── LED_R_PIN        (GPIO 1)  - red PWM channel
     └── LED_G_PIN        (GPIO 30) - green PWM channel

--- a/examples/lighting-app/bouffalolab/bflb/mboard.h
+++ b/examples/lighting-app/bouffalolab/bflb/mboard.h
@@ -27,7 +27,7 @@
 #define CHIP_UART_RX_BUFFSIZE 256
 
 #if defined(BL616CL)
-#define BOOT_PIN_RESET 38
+#define BOOT_PIN_RESET 36
 #elif defined(BL616)
 #define BOOT_PIN_RESET 2
 #endif


### PR DESCRIPTION
  [Bouffalo Lab] Correct BL616CL boot reset pin

  Update Bouffalo Lab lighting app BL616CL board configuration to use GPIO 36 as the boot reset pin.

  Sync the Bouffalo lighting app README so the documented BL616CL BOOT_PIN_RESET matches the board configuration.
