### PR TITLE
[Bouffalo Lab] Fix BL702 Ethernet locking and network stability issues.

### DIFF
--- a/src/platform/bouffalolab/BL702/NetworkCommissioningEthernetDriver.cpp
+++ b/src/platform/bouffalolab/BL702/NetworkCommissioningEthernetDriver.cpp
@@ -20,6 +20,7 @@ extern "C" {
 }
 #include <lwip/dhcp6.h>
 #include <lwip/netifapi.h>
+#include <lwip/tcpip.h>
 
 #include <lib/support/SafePointerCast.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -69,7 +70,7 @@ static int ethernet_callback(eth_link_state val)
 
 CHIP_ERROR BflbEthernetDriver::Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
-    netif_add(&eth_mac, NULL, NULL, NULL, NULL, eth_init, ethernet_input);
+    netif_add(&eth_mac, NULL, NULL, NULL, NULL, eth_init, tcpip_input);
 
     ethernet_init(ethernet_callback);
 

--- a/src/platform/bouffalolab/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConnectivityManagerImpl.cpp
@@ -327,13 +327,19 @@ void ConnectivityManagerImpl::OnConnectivityChanged(struct netif * interface)
 
         if (haveIPv4Conn != hadIPv4Conn)
         {
-            memset(&m_ip4addr, 0, sizeof(ip4_addr_t));
+            if (!haveIPv4Conn)
+            {
+                memset(&m_ip4addr, 0, sizeof(ip4_addr_t));
+            }
             ChipLogProgress(DeviceLayer, "%s Internet connectivity %s", "IPv4", (haveIPv4Conn) ? "ESTABLISHED" : "LOST");
         }
 
         if (haveIPv6Conn != hadIPv6Conn)
         {
-            memset(&m_ip6addr, 0, sizeof(ip6_addr_t) * LWIP_IPV6_NUM_ADDRESSES);
+            if (!haveIPv6Conn)
+            {
+                memset(&m_ip6addr, 0, sizeof(ip6_addr_t) * LWIP_IPV6_NUM_ADDRESSES);
+            }
             ChipLogProgress(DeviceLayer, "%s Internet connectivity %s", "IPv6", (haveIPv6Conn) ? "ESTABLISHED" : "LOST");
         }
     }

--- a/src/platform/bouffalolab/common/Logging.cpp
+++ b/src/platform/bouffalolab/common/Logging.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <FreeRTOS.h>
+#include <semphr.h>
 #include <task.h>
 #if CHIP_DEVICE_LAYER_TARGET_BL602 || CHIP_DEVICE_LAYER_TARGET_BL702 || CHIP_DEVICE_LAYER_TARGET_BL702L
 #include <utils_log.h>
@@ -42,8 +43,22 @@ namespace Logging {
 namespace Platform {
 
 static char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+static StaticSemaphore_t sLogMutexStorage;
+static SemaphoreHandle_t sLogMutex = xSemaphoreCreateMutexStatic(&sLogMutexStorage);
+
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
+    // Logging is synchronous and may block on UART output, so it is not safe from interrupt context.
+    if (xPortIsInsideInterrupt())
+    {
+        return;
+    }
+
+    const bool shouldLock = xTaskGetSchedulerState() == taskSCHEDULER_RUNNING;
+    if (shouldLock && xSemaphoreTake(sLogMutex, portMAX_DELAY) != pdTRUE)
+    {
+        return;
+    }
 #if !PW_RPC_ENABLED
     int lmsg = 0;
 
@@ -115,6 +130,11 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     const char * newline = "\r\n";
     PigweedLogger::putString(newline, strlen(newline));
 #endif
+
+    if (shouldLock)
+    {
+        xSemaphoreGive(sLogMutex);
+    }
 }
 
 } // namespace Platform


### PR DESCRIPTION
### Summary

  Fix BL702 Ethernet locking and network stability issues.

  The Ethernet netif was configured with `ethernet_input`, causing the RX task to enter the lwIP core directly without acquiring
  `lock_tcpip_core`. This could race with other lwIP users and corrupt global protocol state.

  The crash log showed a `Load access fault` in `udp_input_local_match()`. The failing instruction dereferenced
  `ip_data.current_input_netif` while it was `NULL`, which is consistent with concurrent lwIP input processing.

  This change configures the Ethernet netif to use `tcpip_input`. With `LWIP_TCPIP_CORE_LOCKING=1` and
  `LWIP_TCPIP_CORE_LOCKING_INPUT=1`, the packet is processed under the lwIP core lock before calling `ethernet_input`.

  The change also preserves IPv4 and IPv6 address caches when connectivity is established. The caches are cleared only when connectivity
  is lost, preventing duplicate address-change notifications.

  Matter logging is serialized in task context to protect the shared formatting buffer and prevent concurrent log records from being
  corrupted. Logging from interrupt context is skipped because synchronous UART output cannot safely block in an ISR.

  Only the Ethernet input callback, connectivity cache handling, and Bouffalo Lab Matter logging path are changed. The Ethernet RX
  driver, packet buffer handling, low-level EMAC logic, and vendor UART implementation remain unchanged.

  ### Related issues

  No related GitHub issue.

  ### Testing

  - Verified the crash address with `addr2line` against the matching `bridge-release.out` ELF.
  - Verified the failing instruction with RISC-V disassembly.
  - Verified that BL702 enables:
    - `LWIP_TCPIP_CORE_LOCKING=1`
    - `LWIP_TCPIP_CORE_LOCKING_INPUT=1`
  - Verified that `tcpip_input()` acquires the lwIP core lock before calling `ethernet_input`.
  - Reviewed the IPv4 and IPv6 connectivity state transitions.
  - Verified that address caches are preserved on connectivity establishment and cleared on connectivity loss.
  - Verified that task-context Matter logging is serialized.
  - Ran `git diff --check`.
  - Firmware compilation and hardware testing were not performed locally.

  Manual hardware validation is required after building the firmware:

  1. Start the BL702 Ethernet device and wait for IPv4 address assignment.
  2. Establish a Matter CASE session using `chip-tool`.
  3. Create a subscription and perform repeated On/Off commands.
  4. Run `br list` repeatedly while other Matter and platform logs are active.
  5. Keep mDNS, subscription traffic, and OTA requestor periodic queries active.
  6. Reconnect the Ethernet interface and verify that the same IPv4 address is reported only once per assignment.
  7. Run the device for an extended period and monitor for:
     - `Load access fault`
     - crashes in `udp_input` or `ip4_input`
     - watchdog resets
     - `ERR_MEM`
     - Ethernet RX packet loss
     - corrupted or interleaved log lines
     - duplicate IP address-change notifications
